### PR TITLE
UTF8 strings lowercase conversion

### DIFF
--- a/lib/whatlanguage.rb
+++ b/lib/whatlanguage.rb
@@ -33,7 +33,7 @@ class WhatLanguage
   def process_text(text)
     results = Hash.new(0)
     it = 0
-    text.downcase.split.each do |word|
+    to_lowercase(text).split.each do |word|
       it += 1
 
       languages.each do |lang|
@@ -61,6 +61,12 @@ class WhatLanguage
     bf = BloominSimple.new(BITFIELD_WIDTH, &HASHER)
     File.open(filename).each { |word| bf.add(word) }
     bf
+  end
+
+  if !defined? UnicodeUtils
+    define_method(:to_lowercase) { |str| str.downcase }
+  else
+    define_method(:to_lowercase) { |str| UnicodeUtils.casefold(str) }
   end
 end
 

--- a/test/test_whatlanguage.rb
+++ b/test/test_whatlanguage.rb
@@ -1,6 +1,12 @@
 # encoding: utf-8
 require "test/unit"
 
+# not a dependency
+begin
+  require 'unicode_utils'
+rescue LoadError
+end
+
 require 'whatlanguage'
 
 class TestWhatLanguage < Test::Unit::TestCase
@@ -113,5 +119,10 @@ class TestWhatLanguage < Test::Unit::TestCase
   def test_language_selection_mixed
     selective_wl = WhatLanguage.new(:german, :all, :english)
     assert_equal :russian, selective_wl.language("Все новости в хронологическом порядке")
+  end
+
+  def test_casing_conversion
+    skip unless defined? UnicodeUtils
+    assert_equal "âncora cor âmbar".language, "ÂNCORA COR ÂMBAR".language
   end
 end


### PR DESCRIPTION
Currently, `process_text` converts the given string to lowercase in order to perform the word matching, but unfortunately Ruby does not convert UTF8 strings properly.
I've noticed inconsistencies like this one:

``` ruby
require 'whatlanguage'
puts "ÂNCORA COR ÂMBAR".language # => spanish
puts "âncora cor âmbar".language # => portuguese
```

Thanks for the library!
