### PR TITLE
Allow usage without extending String

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This library has been updated to be distributed and to work on modern Ruby imple
 Full Example
 
 ```ruby
-require 'whatlanguage'
+require 'whatlanguage/string'
 
 texts = []
 texts << %q{Deux autres personnes ont été arrêtées durant la nuit}

--- a/lib/whatlanguage.rb
+++ b/lib/whatlanguage.rb
@@ -99,13 +99,3 @@ class WhatLanguage
     define_method(:to_lowercase) { |str| UnicodeUtils.casefold(str) }
   end
 end
-
-class String
-  def language
-    WhatLanguage.new(:all).language(self)
-  end
-
-  def language_iso
-    WhatLanguage.new(:all).language_iso(self)
-  end
-end

--- a/lib/whatlanguage/string.rb
+++ b/lib/whatlanguage/string.rb
@@ -1,0 +1,11 @@
+require 'whatlanguage'
+
+class String
+  def language
+    WhatLanguage.new(:all).language(self)
+  end
+
+  def language_iso
+    WhatLanguage.new(:all).language_iso(self)
+  end
+end

--- a/test/test_whatlanguage.rb
+++ b/test/test_whatlanguage.rb
@@ -7,7 +7,7 @@ begin
 rescue LoadError
 end
 
-require 'whatlanguage'
+require 'whatlanguage/string'
 
 class TestWhatLanguage < Test::Unit::TestCase
   def setup


### PR DESCRIPTION
I was looking into using this in combination with [Scylla](https://github.com/hashwin/scylla), but both libraries extend the core `String` with the method `#language`. I suggest you make the core extension optional. (I will try to make the same suggestion to the author of Scylla.)

I changed the require statements in the examples and the tests to still include the core extension, but haven't explained how to use the library without it. I guess your english would be preferable ...