### PR TITLE
correct require path

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This library has been updated to be distributed and to work on modern Ruby imple
 Full Example
 
 ```ruby
-require 'whatlanguage/string'
+require 'whatlanguage'
 
 texts = []
 texts << %q{Deux autres personnes ont été arrêtées durant la nuit}


### PR DESCRIPTION
the example as currently written does not work in the latest gem; this fixes