### PR TITLE
Minor memory efficiency improvement for Ruby 2.1+

### DIFF
--- a/lib/whatlanguage.rb
+++ b/lib/whatlanguage.rb
@@ -3,7 +3,7 @@ require 'whatlanguage/bitfield'
 require 'digest/sha1'
 
 class WhatLanguage
-  HASHER = lambda { |item| Digest::SHA1.digest(item.downcase.strip).unpack("VV") }
+  HASHER = lambda { |item| Digest::SHA1.digest(item.downcase.strip).unpack("VV".freeze) }
 
   BITFIELD_WIDTH = 2_000_000
 


### PR DESCRIPTION
Using the `memory_profiler` gem, I noticed a significant number of "VV" allocations during a job that checks the language of many relatively short strings.