### PR TITLE
Correct require path in readme.md for version 1.0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This library has been updated to be distributed and to work on modern Ruby imple
 Full Example
 
 ```ruby
-require 'whatlanguage'
+require 'whatlanguage/string'
 
 texts = []
 texts << %q{Deux autres personnes ont été arrêtées durant la nuit}
@@ -80,7 +80,7 @@ None, minor libraries (BloominSimple and BitField) included with this release.
 To test, go into irb, then:
 
 ```ruby
-require 'whatlanguage'
+require 'whatlanguage/string'
 "Je suis un homme".language
 ```
 


### PR DESCRIPTION
The example as currently written does not work in the latest version(1.0.6) of gem; This fixes

Here is the sample code I ran on my machine:

``` ruby
$ irb --simple-prompt
>> require 'whatlanguage'
=> true
>> "This is a test".language 
NoMethodError: undefined method `language' for "This is a test":String
    from (irb):2
    from /home/prakash/.rvm/rubies/ruby-2.3.0/bin/irb:11:in `<main>'
>> require 'whatlanguage/string'
=> true
>> "This is a test".language 
=> :polish

```
