### PR TITLE
Fix header definition for Credits

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ require 'whatlanguage'
 "Je suis un homme".language
 ```
 
-## Credits
+## Credits
 
 Contributions from Konrad Reiche, Salimane Adjao Moustapha, and others appreciated.
 


### PR DESCRIPTION
The two hashes (`##`) were followed by a [*no-break space*](http://www.fileformat.info/info/unicode/char/00a0/index.htm) (`U+00A0`). Replaced with the proper [*space*](http://www.fileformat.info/info/unicode/char/0020/index.htm) (`U+0020`).